### PR TITLE
fix: remove useRuntimeConfig from server utilities

### DIFF
--- a/packages/authjs-nuxt/src/runtime/lib/server.ts
+++ b/packages/authjs-nuxt/src/runtime/lib/server.ts
@@ -63,7 +63,7 @@ export async function getServerSession(
  * @param options AuthConfig
  * @returns JWT Token
  */
-export async function getServerToken(event: H3Event, options: AuthConfig) {
+export async function getServerToken(event: H3Event, options: AuthConfig, runtimeConfig?: Partial<RuntimeConfig>) {
   const response = await getServerSessionResponse(event, options)
   const cookies = Object.fromEntries(response.headers.entries())
   const parsedCookies = makeCookiesFromCookieString(cookies["set-cookie"])
@@ -73,7 +73,7 @@ export async function getServerToken(event: H3Event, options: AuthConfig) {
       headers: response.headers as unknown as Record<string, string>
     },
     // see https://github.com/nextauthjs/next-auth/blob/a79774f6e890b492ae30201f24b3f7024d0d7c9d/packages/core/src/jwt.ts
-    secureCookie: getServerOrigin(event).startsWith("https://"),
+    secureCookie: getServerOrigin(event, runtimeConfig).startsWith("https://"),
     secret: getAuthJsSecret(options)
   }
   return getToken(parameters)

--- a/packages/authjs-nuxt/src/runtime/utils.ts
+++ b/packages/authjs-nuxt/src/runtime/utils.ts
@@ -16,9 +16,9 @@ export function getAuthJsSecret(options: AuthConfig) {
   return secret
 }
 
-export function getServerOrigin(event: H3Event) {
+export function getServerOrigin(event: H3Event, runtimeConfig?: Partial<RuntimeConfig>) {
   const requestOrigin = getRequestHeaders(event).Origin
-  const serverOrigin = useRuntimeConfig().public?.authJs?.baseUrl
+  const serverOrigin = runtimeConfig?.public?.authJs?.baseUrl ?? ""
   const origin = requestOrigin ?? serverOrigin.length > 0 ? serverOrigin : process.env.AUTH_ORIGIN
   if (!origin) throw new Error("No Origin found ...")
   return origin


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Fix #30 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`getServerToken` now accept `useRuntimeConfig` as an optional 3rd argument. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
