### PR TITLE
fix(app): navigateTo is not defined error

### DIFF
--- a/packages/authjs-nuxt/src/runtime/middleware/guest-only.ts
+++ b/packages/authjs-nuxt/src/runtime/middleware/guest-only.ts
@@ -1,5 +1,5 @@
 import { useAuth } from "../composables/useAuth"
-import { defineNuxtRouteMiddleware } from "#imports"
+import { defineNuxtRouteMiddleware, navigateTo, useRuntimeConfig } from "#imports"
 
 /**
  * Prevents authenticated users from accessing guest-only pages. Ideal for pages like login and register.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request is meant to resolve the error: `error caught during app initialization ReferenceError: navigateTo is not defined` by importing `navigateTo` in the `guest-only` middleware.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
