### PR TITLE
fix: getServerToken returns null when used in middleware

### DIFF
--- a/packages/authjs-nuxt/src/runtime/lib/server.ts
+++ b/packages/authjs-nuxt/src/runtime/lib/server.ts
@@ -1,7 +1,7 @@
 import type { RuntimeConfig } from "nuxt/schema"
 import { Auth, skipCSRFCheck } from "@auth/core"
 import type { H3Event } from "h3"
-import { eventHandler, getRequestHeaders, getRequestURL } from "h3"
+import { eventHandler, getRequestHeaders, getRequestURL, parseCookies } from "h3"
 import type { AuthConfig, Session } from "@auth/core/types"
 import { getToken } from "@auth/core/jwt"
 import { checkOrigin, getAuthJsSecret, getRequestFromEvent, getServerOrigin, makeCookiesFromCookieString } from "../utils"
@@ -65,11 +65,11 @@ export async function getServerSession(
  */
 export async function getServerToken(event: H3Event, options: AuthConfig, runtimeConfig?: Partial<RuntimeConfig>) {
   const response = await getServerSessionResponse(event, options)
-  const cookies = Object.fromEntries(response.headers.entries())
-  const parsedCookies = makeCookiesFromCookieString(cookies["set-cookie"])
+  const cookies = parseCookies(event)
+
   const parameters = {
     req: {
-      cookies: parsedCookies,
+      cookies,
       headers: response.headers as unknown as Record<string, string>
     },
     // see https://github.com/nextauthjs/next-auth/blob/a79774f6e890b492ae30201f24b3f7024d0d7c9d/packages/core/src/jwt.ts

--- a/packages/authjs-nuxt/src/runtime/lib/server.ts
+++ b/packages/authjs-nuxt/src/runtime/lib/server.ts
@@ -4,7 +4,7 @@ import type { H3Event } from "h3"
 import { eventHandler, getRequestHeaders, getRequestURL, parseCookies } from "h3"
 import type { AuthConfig, Session } from "@auth/core/types"
 import { getToken } from "@auth/core/jwt"
-import { checkOrigin, getAuthJsSecret, getRequestFromEvent, getServerOrigin, makeCookiesFromCookieString } from "../utils"
+import { checkOrigin, getAuthJsSecret, getRequestFromEvent, getServerOrigin } from "../utils"
 
 if (!globalThis.crypto) {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
### 🔗 Linked issue
#139 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When using getServerToken in a middleware the function returns null because it can't read the cookies.
I changed your cookie parsing from the headers to using the h3 function [`parseCookies`](https://www.jsdocs.io/package/h3#parseCookies)

Resolves #139 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
