### PR TITLE
feat: Allow passing an async function to NuxtAuthHandler

### DIFF
--- a/docs/nuxt-configuration.md
+++ b/docs/nuxt-configuration.md
@@ -40,7 +40,9 @@ You *must* create a catch-all route at `server/api/auth/[...].ts`.
 ```ts
 import GithubProvider from "@auth/core/providers/github"
 import type { AuthConfig } from "@auth/core/types"
+import type { H3Event } from "h3"
 import { NuxtAuthHandler } from "#auth"
+import { D1Adapter } from "@auth/d1-adapter"
 
 // The #auth virtual import comes from this module. You can use it on the client
 // and server side, however not every export is universal. For example do not
@@ -57,6 +59,25 @@ export const authOptions: AuthConfig = {
       clientSecret: runtimeConfig.github.clientSecret
     })
   ]
+}
+
+// authOptions can either be passed as an object like above,
+//  or as an async function which has the event as it's argument
+//  this is especially useful for database adapters that need access to the event object,
+//  such as D1Adapter
+export async function authOptions (event: H3Event) {
+  const authOptions: AuthConfig = {
+    secret: runtimeConfig.authJs.secret,
+    providers: [
+      GithubProvider({
+        clientId: runtimeConfig.github.clientId,
+        clientSecret: runtimeConfig.github.clientSecret
+      })
+    ],
+    adapter: D1Adapter(event.context.cloudflare.env.db)
+  }
+
+  return authOptions
 }
 
 export default NuxtAuthHandler(authOptions, runtimeConfig)

--- a/packages/authjs-nuxt/src/runtime/lib/server.ts
+++ b/packages/authjs-nuxt/src/runtime/lib/server.ts
@@ -21,12 +21,16 @@ if (!globalThis.crypto) {
 /**
  * This is the event handler for the catch-all route.
  * Everything can be customized by adding a custom route that takes priority over the handler.
- * @param options AuthConfig
+ * @param options AuthConfig|Function
  * @param runtimeConfig RuntimeConfig
  * @returns EventHandler
  */
-export function NuxtAuthHandler(options: AuthConfig, runtimeConfig: RuntimeConfig) {
+export function NuxtAuthHandler(options: AuthConfig|Function, runtimeConfig: RuntimeConfig) {
   return eventHandler(async (event) => {
+    if (typeof options === 'function') {
+      options = await options(event) as AuthConfig
+    }
+
     options.trustHost ??= true
     options.skipCSRFCheck = skipCSRFCheck
     const request = await getRequestFromEvent(event)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/Hebilicious/authjs-nuxt/issues/138

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`NuxtAuthHandler` accepts `options` and `runtimeConfig` in order to build a response as part of the `/api/auth/[...]` endpoint.

Some adapters, such as [D1Adapter](https://authjs.dev/reference/adapter/d1), need access to the event in order to connect to the database.

The current solution of passing `options` as an `object` does not expose the event.

This PR allows passing `options` as an async function, which takes `event` as its argument. That way, users of this package, can extend it, and add any adapter, or other logic that they want.

Resolves #138 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
