### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/packages/authjs-nuxt/src/runtime/middleware/client-auth.ts
+++ b/packages/authjs-nuxt/src/runtime/middleware/client-auth.ts
@@ -8,7 +8,7 @@ import { defineNuxtRouteMiddleware, navigateTo, useRuntimeConfig } from "#import
  */
 
 export default defineNuxtRouteMiddleware(async (to) => {
-  if (process.server) return
+  if (import.meta.server) return
   const valid = await verifyClientSession()
   if (valid) return
   if (["client-auth", "auth"].includes(to.meta.middleware) || to.meta.auth === true)

--- a/packages/authjs-nuxt/src/runtime/plugin.ts
+++ b/packages/authjs-nuxt/src/runtime/plugin.ts
@@ -5,7 +5,7 @@ import { defineNuxtPlugin, useRequestHeaders } from "#app"
 
 export default defineNuxtPlugin(async () => {
   // We try to get the session when the app SSRs. No need to repeat this on the client.
-  if (process.server) {
+  if (import.meta.server) {
     const { updateSession, removeSession, cookies } = useAuth()
     const headers = useRequestHeaders() as any
     const data = await $fetch<Session>("/api/auth/session", {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
